### PR TITLE
Add default values and enum for plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SVG Icon Compose
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.10-blue.svg)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.21-blue.svg)](https://kotlinlang.org)
 [![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-1.9.3-blue.svg)](https://www.jetbrains.com/lp/compose-multiplatform/)
 
 A Kotlin Multiplatform library for rendering SVG icons in Compose Multiplatform applications with compile-time code generation.
@@ -102,15 +102,13 @@ src/commonMain/composeResources/svg/
 └── menu.svg
 ```
 
-### 2. Configure code generation
+### 2. Configure code generation (optional)
 
-Add to your `build.gradle.kts`:
+The plugin works with sensible defaults. Just apply the plugin and you're done:
 
 ```kotlin
-svgIcon {
-    svgDir.set(file("src/commonMain/composeResources/svg"))
-    packageName.set("com.example.icons")
-    visibility.set("public")  // or "internal"
+plugins {
+    id("io.github.fuyuz.svgicon") version "0.1.0"
 }
 
 kotlin {
@@ -119,6 +117,18 @@ kotlin {
             kotlin.srcDir(layout.buildDirectory.dir("generated/compose/resourceGenerator/kotlin/svgicons"))
         }
     }
+}
+```
+
+For custom configuration:
+
+```kotlin
+import io.github.fuyuz.svgicon.gradle.IconVisibility
+
+svgIcon {
+    svgDir = file("src/commonMain/composeResources/svg")  // default
+    packageName = "com.example.icons"                      // default: "${project.group}.icons"
+    visibility = IconVisibility.PUBLIC                     // default: PUBLIC
 }
 ```
 
@@ -220,7 +230,7 @@ fun DynamicIcon() {
 
 ## Requirements
 
-- Kotlin 2.1.10+
+- Kotlin 2.1.21+
 - Compose Multiplatform 1.9.3+
 - Java 17+
 

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/GenerateSvgIconsTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/GenerateSvgIconsTask.kt
@@ -26,7 +26,7 @@ abstract class GenerateSvgIconsTask : DefaultTask() {
     abstract val packageName: Property<String>
 
     @get:Input
-    abstract val visibility: Property<String>
+    abstract val visibility: Property<IconVisibility>
 
     init {
         group = "svgicon"
@@ -38,7 +38,7 @@ abstract class GenerateSvgIconsTask : DefaultTask() {
         val svgDirectory = svgDir.get().asFile
         val outputDirectory = outputDir.get().asFile
         val pkg = packageName.get()
-        val vis = visibility.getOrElse("public")
+        val vis = visibility.get()
 
         if (!svgDirectory.exists()) {
             logger.warn("SVG directory does not exist: ${svgDirectory.absolutePath}")
@@ -58,12 +58,7 @@ abstract class GenerateSvgIconsTask : DefaultTask() {
 
         logger.lifecycle("Generating icons from ${svgDirectory.absolutePath}")
 
-        val iconVisibility = when (vis.lowercase()) {
-            "public" -> IconVisibility.PUBLIC
-            else -> IconVisibility.INTERNAL
-        }
-
-        val generator = IconGenerator(visibility = iconVisibility)
+        val generator = IconGenerator(visibility = vis)
         val iconNames = generator.generateIcons(svgDirectory, pkg, outputDirectory)
 
         logger.lifecycle("Generated ${iconNames.size} icons")

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/IconGenerator.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/IconGenerator.kt
@@ -6,14 +6,6 @@ import io.github.fuyuz.svgicon.core.*
 import java.io.File
 
 /**
- * Visibility modifier for generated icons.
- */
-enum class IconVisibility {
-    PUBLIC,
-    INTERNAL
-}
-
-/**
  * Generates Kotlin icon files from SVG files using KotlinPoet.
  */
 class IconGenerator(

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/SvgIconExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/SvgIconExtension.kt
@@ -4,31 +4,49 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 
 /**
+ * Visibility modifier for generated icon classes.
+ */
+enum class IconVisibility {
+    PUBLIC,
+    INTERNAL
+}
+
+/**
  * Extension for configuring SVG icon generation.
  *
- * Usage in build.gradle.kts:
+ * All properties have sensible defaults, so minimal configuration is needed:
+ * ```kotlin
+ * plugins {
+ *     id("io.github.fuyuz.svgicon")
+ * }
+ * // That's it! Uses default svgDir and packageName
+ * ```
+ *
+ * Custom configuration:
  * ```kotlin
  * svgIcon {
  *     svgDir.set(file("src/commonMain/composeResources/svg"))
  *     packageName.set("com.example.icons")
- *     visibility.set("public") // or "internal"
+ *     visibility.set(IconVisibility.INTERNAL)
  * }
  * ```
  */
 abstract class SvgIconExtension {
     /**
      * Directory containing SVG files to process.
+     * Defaults to "src/commonMain/composeResources/svg".
      */
     abstract val svgDir: DirectoryProperty
 
     /**
      * Package name for generated icon classes.
+     * Defaults to "${project.group}.icons".
      */
     abstract val packageName: Property<String>
 
     /**
-     * Visibility modifier for generated classes ("public" or "internal").
-     * Defaults to "public".
+     * Visibility modifier for generated classes.
+     * Defaults to [IconVisibility.PUBLIC].
      */
-    abstract val visibility: Property<String>
+    abstract val visibility: Property<IconVisibility>
 }

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/SvgIconPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/gradle/SvgIconPlugin.kt
@@ -11,11 +11,14 @@ import org.gradle.api.Project
  * plugins {
  *     id("io.github.fuyuz.svgicon")
  * }
+ * ```
  *
+ * Optional configuration:
+ * ```kotlin
  * svgIcon {
- *     svgDir.set(file("src/commonMain/composeResources/svg"))
- *     packageName.set("com.example.icons")
- *     visibility.set("public")
+ *     svgDir.set(file("src/commonMain/composeResources/svg"))  // default
+ *     packageName.set("${project.group}.icons")                 // default
+ *     visibility.set(IconVisibility.PUBLIC)                     // default
  * }
  * ```
  */
@@ -26,7 +29,9 @@ class SvgIconPlugin : Plugin<Project> {
         val extension = project.extensions.create("svgIcon", SvgIconExtension::class.java)
 
         // Set default values
-        extension.visibility.convention("public")
+        extension.svgDir.convention(project.layout.projectDirectory.dir("src/commonMain/composeResources/svg"))
+        extension.packageName.convention(project.provider { "${project.group}.icons" })
+        extension.visibility.convention(IconVisibility.PUBLIC)
 
         // Default output directory
         val outputDir = project.layout.buildDirectory.dir("generated/compose/resourceGenerator/kotlin/svgicons")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\=
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
+org.gradle.kotlin.dsl.propertyAssignment=true
 
 # Kotlin
 kotlin.code.style=official

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import io.github.fuyuz.svgicon.gradle.IconVisibility
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -8,9 +9,9 @@ plugins {
 }
 
 svgIcon {
-    svgDir.set(file("src/commonMain/composeResources/svg"))
-    packageName.set("io.github.fuyuz.svgicon.sample.generated.icons")
-    visibility.set("public")
+    // svgDir defaults to "src/commonMain/composeResources/svg"
+    packageName = "io.github.fuyuz.svgicon.sample.generated.icons"
+    visibility = IconVisibility.PUBLIC
 }
 
 kotlin {


### PR DESCRIPTION
## Summary
- Add default `svgDir`: `src/commonMain/composeResources/svg`
- Add default `packageName`: `${project.group}.icons`
- Change `visibility` from String to `IconVisibility` enum (PUBLIC/INTERNAL)
- Enable Gradle property assignment (`=`) syntax
- Update README with new configuration examples

## Usage

Minimal configuration (uses defaults):
```kotlin
plugins {
    id("io.github.fuyuz.svgicon") version "0.1.0"
}
```

Custom configuration:
```kotlin
import io.github.fuyuz.svgicon.gradle.IconVisibility

svgIcon {
    svgDir = file("custom/path")
    packageName = "com.example.icons"
    visibility = IconVisibility.INTERNAL
}
```

## Test plan
- [x] Verify plugin compiles
- [x] Verify sample compiles with new syntax