### PR TITLE
Fix: CI build job to properly fail when build-target fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,13 @@ jobs:
 
   build:
     needs: build-target
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All builds passed"
+      - name: Check build results
+        run: |
+          if [[ "${{ needs.build-target.result }}" != "success" ]]; then
+            echo "Build failed: ${{ needs.build-target.result }}"
+            exit 1
+          fi
+          echo "All builds passed"


### PR DESCRIPTION
## Summary
Fixes an issue where PRs with failing CI could be merged due to GitHub Rulesets treating SKIPPED status as success.

## Problem
The `build` job depends on `build-target` jobs. When any `build-target` failed:
1. `build` job was **SKIPPED** (not executed)
2. GitHub Rulesets treat SKIPPED as success
3. PRs could be merged despite CI failures

## Solution
- Add `if: always()` to ensure `build` job always runs
- Explicitly check `needs.build-target.result` and fail if not `success`

## Test plan
- [x] When all build-target jobs pass → build job passes
- [x] When any build-target job fails → build job fails (not SKIPPED)