### PR TITLE
Add preserveAspectRatio to svg() DSL function

### DIFF
--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDsl.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDsl.kt
@@ -2156,6 +2156,7 @@ inline fun svg(block: SvgBuilder.() -> Unit): Svg {
  * @param strokeWidth Default stroke width (default: 2f)
  * @param strokeLinecap Default stroke line cap (default: ROUND)
  * @param strokeLinejoin Default stroke line join (default: ROUND)
+ * @param preserveAspectRatio Aspect ratio handling (default: xMidYMid meet)
  * @param block Builder block for adding SVG elements
  */
 inline fun svg(
@@ -2167,10 +2168,14 @@ inline fun svg(
     strokeWidth: Float = 2f,
     strokeLinecap: LineCap = LineCap.ROUND,
     strokeLinejoin: LineJoin = LineJoin.ROUND,
+    preserveAspectRatio: PreserveAspectRatio = PreserveAspectRatio.Default,
     block: SvgBuilder.() -> Unit
 ): Svg {
     return Svg(
+        width = width.toFloat(),
+        height = height.toFloat(),
         viewBox = viewBox ?: ViewBox(0f, 0f, width.toFloat(), height.toFloat()),
+        preserveAspectRatio = preserveAspectRatio,
         fill = fill,
         stroke = stroke,
         strokeWidth = strokeWidth,


### PR DESCRIPTION
## Summary
- Add `preserveAspectRatio` parameter to the customizable `svg()` DSL overload
- Pass `width`/`height` to `Svg` constructor (was previously missing)

## Changes
The `svg()` function now supports all `Svg` constructor parameters:

```kotlin
svg(
    width = 100,
    height = 100,
    viewBox = ViewBox(0f, 0f, 100f, 100f),
    preserveAspectRatio = PreserveAspectRatio.None,
    fill = Color.Red,
    stroke = Color.Blue,
    strokeWidth = 2f,
    strokeLinecap = LineCap.ROUND,
    strokeLinejoin = LineJoin.ROUND
) {
    path("M50 10 L90 90 L10 90 Z")
}
```

## Test Plan
- [x] All runtime tests pass
- [x] Sample module builds successfully