### PR TITLE
Fix FillOpacity and StrokeDashoffset animations not working

### DIFF
--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
@@ -642,9 +642,7 @@ internal object SvgXmlParser {
             }
             "stroke-dashoffset" -> {
                 if (effectiveFrom != null && effectiveTo != null) {
-                    // stroke-dashoffset from high to low (e.g., 50 to 0) = stroke appearing (normal)
-                    // stroke-dashoffset from low to high (e.g., 0 to 50) = stroke disappearing (reverse)
-                    SvgAnimate.StrokeDraw(dur, delay, reverse = effectiveFrom < effectiveTo, calcMode, keySplines)
+                    SvgAnimate.StrokeDashoffset(effectiveFrom, effectiveTo, dur, delay, calcMode, keySplines)
                 } else null
             }
             "cx" -> {

--- a/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
@@ -2542,7 +2542,7 @@ class SvgParserTest {
     }
 
     @Test
-    fun parseAnimateStrokeDashoffsetReverse() {
+    fun parseAnimateStrokeDashoffset() {
         val svg = svg("""
             <svg>
                 <path d="M10 10 L20 20">
@@ -2553,9 +2553,11 @@ class SvgParserTest {
         assertEquals(1, svg.children.size)
         assertIs<SvgAnimated>(svg.children[0])
         val animated = svg.children[0] as SvgAnimated
-        val strokeDraw = animated.animations[0]
-        assertIs<SvgAnimate.StrokeDraw>(strokeDraw)
-        assertTrue(strokeDraw.reverse) // from < to means reverse
+        val strokeDashoffset = animated.animations[0]
+        assertIs<SvgAnimate.StrokeDashoffset>(strokeDashoffset)
+        assertEquals(0f, strokeDashoffset.from)
+        assertEquals(100f, strokeDashoffset.to)
+        assertEquals(1000.milliseconds, strokeDashoffset.dur)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix FillOpacity and StrokeDashoffset animations that were not being applied when elements are wrapped in SvgStyled
- Fix SVG parser incorrectly converting stroke-dashoffset animations to StrokeDraw

## Root Cause
1. **drawAnimatedInnerElement else clause**: When SvgStyled elements fell through to the else clause, they called `drawSvgElement()` which then called `applyStyle()`, overwriting the animated opacity and dashoffset values
2. **SVG Parser bug**: `<animate attributeName="stroke-dashoffset">` was incorrectly converted to `SvgAnimate.StrokeDraw` instead of `SvgAnimate.StrokeDashoffset`

## Changes
### SvgIcon.kt
- Add explicit cases for SvgStyled, SvgPath, SvgPolyline, SvgPolygon, SvgGroup, SvgText in `drawAnimatedInnerElement()`
- Add `applyStylePreservingAnimation()` function to apply styles while preserving animation state
- Add `buildPathEffectPreservingAnimation()` for animated strokeDashoffset

### SvgParser.kt
- Fix stroke-dashoffset parsing to create `SvgAnimate.StrokeDashoffset` instead of `SvgAnimate.StrokeDraw`

### SvgParserTest.kt
- Update test to expect `SvgAnimate.StrokeDashoffset` with correct from/to values

## Test plan
- [x] Runtime tests pass
- [x] Sample app compiles and runs
- [x] FillOpacity animation works on SvgStyled elements
- [x] StrokeDashoffset animation works on SvgStyled elements