### PR TITLE
Fix release OOM: remove redundant build step and increase heap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,18 +40,16 @@ jobs:
           sed -i '' "s/version = \".*\"/version = \"$VERSION\"/" build.gradle.kts
           sed -i '' "s/version = \".*\"/version = \"$VERSION\"/" gradle-plugin/build.gradle.kts
 
-      - name: Build
-        run: ./gradlew build
-
       - name: Publish to Maven Central
         env:
+          GRADLE_OPTS: "-Xmx4g"
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          ./gradlew publishAllPublicationsToMavenCentralRepository
-          ./gradlew :gradle-plugin:publishAllPublicationsToMavenCentralRepository
+          ./gradlew publishAllPublicationsToMavenCentralRepository --no-daemon
+          ./gradlew :gradle-plugin:publishAllPublicationsToMavenCentralRepository --no-daemon
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Fix OutOfMemoryError in release workflow

## Changes
- Remove redundant `./gradlew build` step (publish triggers build automatically)
- Add `GRADLE_OPTS: "-Xmx4g"` for increased heap
- Add `--no-daemon` to release memory between tasks

## Test plan
- [ ] Re-run release workflow with v0.1.0 tag