### PR TITLE
Fix release: add permissions for GitHub Release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary
- Fix 403 error when creating GitHub Release

## Changes
- Add `permissions: contents: write` to release workflow

## Test plan
- [ ] Re-run release workflow