### PR TITLE
Align animation default values with SVG/SMIL spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Aligned animation default values with SVG/SMIL spec (#55):
+  - `dur` defaults to `indefinite` (Duration.INFINITE) instead of `500ms`
+  - `repeatCount` defaults to `1` (single iteration) instead of `indefinite` (-1)
+  - `animateMotion` `calcMode` defaults to `paced` instead of `linear`
 - Aligned default fill behavior with SVG spec: `fill` now defaults to `black` instead of `none` (#34)
 - Aligned default stroke properties with SVG spec (#35):
   - `stroke` defaults to `none` (null) instead of `currentColor`

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgAnimation.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgAnimation.kt
@@ -4,8 +4,12 @@ import androidx.compose.ui.geometry.Offset
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-/** Default animation duration */
-val DefaultAnimationDuration = 500.milliseconds
+/**
+ * Default animation duration per SVG/SMIL spec.
+ * When dur is not specified, SVG/SMIL spec defines it as "indefinite".
+ * Duration.INFINITE represents this indefinite duration.
+ */
+val DefaultAnimationDuration: Duration = Duration.INFINITE
 
 /**
  * SVG calcMode attribute for animation timing.
@@ -121,7 +125,7 @@ sealed interface SvgAnimate {
         val reverse: Boolean = false,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -136,7 +140,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -151,7 +155,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -166,7 +170,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -181,7 +185,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -200,7 +204,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -219,7 +223,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -238,7 +242,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -253,7 +257,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -268,7 +272,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -283,7 +287,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -298,7 +302,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -313,7 +317,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -328,7 +332,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -343,7 +347,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -358,7 +362,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -373,7 +377,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -388,7 +392,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -403,7 +407,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -418,7 +422,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -433,7 +437,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -448,7 +452,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate
@@ -473,7 +477,7 @@ sealed interface SvgAnimate {
         override val delay: Duration = Duration.ZERO,
         override val calcMode: CalcMode = CalcMode.LINEAR,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE,
         /** Y value for translate (from). Only used when type is TRANSLATE. */
@@ -491,15 +495,18 @@ sealed interface SvgAnimate {
     /**
      * Motion animation (animateMotion).
      * Moves the element along a path.
+     *
+     * Note: Per SVG/SMIL spec, animateMotion defaults to calcMode="paced"
+     * (unlike other animation elements which default to "linear").
      */
     data class Motion(
         val path: String,
         override val dur: Duration = DefaultAnimationDuration,
         override val delay: Duration = Duration.ZERO,
         val rotate: MotionRotate = MotionRotate.NONE,
-        override val calcMode: CalcMode = CalcMode.LINEAR,
+        override val calcMode: CalcMode = CalcMode.PACED,
         override val keySplines: KeySplines? = null,
-        override val iterations: Int = INFINITE,
+        override val iterations: Int = 1,
         override val direction: AnimationDirection = AnimationDirection.NORMAL,
         override val fillMode: AnimationFillMode = AnimationFillMode.NONE
     ) : SvgAnimate

--- a/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgAnimationTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgAnimationTest.kt
@@ -17,8 +17,9 @@ class SvgAnimationTest {
     // ===========================================
 
     @Test
-    fun defaultAnimationDurationIs500ms() {
-        assertEquals(500.milliseconds, DefaultAnimationDuration)
+    fun defaultAnimationDurationIsInfinite() {
+        // Per SVG/SMIL spec, unspecified dur defaults to "indefinite"
+        assertEquals(Duration.INFINITE, DefaultAnimationDuration)
     }
 
     // ===========================================
@@ -153,7 +154,8 @@ class SvgAnimationTest {
         assertFalse(anim.reverse)
         assertEquals(CalcMode.LINEAR, anim.calcMode)
         assertNull(anim.keySplines)
-        assertEquals(SvgAnimate.INFINITE, anim.iterations)
+        // Per SVG/SMIL spec, repeatCount defaults to 1 (single iteration)
+        assertEquals(1, anim.iterations)
         assertEquals(AnimationDirection.NORMAL, anim.direction)
         assertEquals(AnimationFillMode.NONE, anim.fillMode)
     }
@@ -435,7 +437,10 @@ class SvgAnimationTest {
         assertEquals(DefaultAnimationDuration, anim.dur)
         assertEquals(Duration.ZERO, anim.delay)
         assertEquals(MotionRotate.NONE, anim.rotate)
-        assertEquals(CalcMode.LINEAR, anim.calcMode)
+        // Per SVG/SMIL spec, animateMotion defaults to calcMode="paced"
+        assertEquals(CalcMode.PACED, anim.calcMode)
+        // Per SVG/SMIL spec, repeatCount defaults to 1 (single iteration)
+        assertEquals(1, anim.iterations)
     }
 
     @Test

--- a/sample/src/commonMain/svgicons/animation-defaults-demo.svg
+++ b/sample/src/commonMain/svgicons/animation-defaults-demo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- This demo shows SVG/SMIL spec-compliant animation defaults:
+       - dur: indefinite (runs forever when not specified)
+       - repeatCount: 1 (single iteration)
+       - animateMotion calcMode: paced (constant velocity)
+
+       Note: Since default repeatCount is 1, animations with explicit
+       dur will play once and stop. Use repeatCount="indefinite" for loops. -->
+
+  <!-- Circle with explicit 2s duration - plays once then holds (repeatCount=1 default) -->
+  <circle cx="12" cy="12" r="4">
+    <animate attributeName="r" from="4" to="8" dur="2s" fill="freeze"/>
+  </circle>
+
+  <!-- Moving dot with paced motion along path (animateMotion default calcMode=paced) -->
+  <circle cx="0" cy="0" r="2" fill="currentColor">
+    <animateMotion path="M4,12 C4,4 20,4 20,12 C20,20 4,20 4,12" dur="3s" repeatCount="indefinite"/>
+  </circle>
+</svg>


### PR DESCRIPTION
## Summary
- Aligned animation default values with the SVG/SMIL specification
- `dur` now defaults to `indefinite` (Duration.INFINITE) instead of `500ms`
- `repeatCount` now defaults to `1` (single iteration) instead of `indefinite` (-1)  
- `animateMotion` `calcMode` now defaults to `paced` instead of `linear`

## Changes
- Updated `SvgAnimation.kt` to use spec-compliant default values
- Updated `SvgAnimationTest.kt` to verify new defaults
- Added `animation-defaults-demo.svg` sample icon demonstrating the defaults
- Updated CHANGELOG.md

## Test plan
- [x] Unit tests pass (`./gradlew :runtime:desktopTest`)
- [x] Sample compiles (`./gradlew :sample:compileKotlinDesktop`)
- [x] Sample icon generated (`./gradlew :sample:generateSvgIcons`)

Closes #55