### PR TITLE
Add visibility and display attribute support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Implemented `paint-order` attribute support for controlling fill/stroke drawing order (#40)
 - Added support for `inherit` keyword in style attributes (fill, stroke, opacity, stroke-width, etc.) (#61)
 - Added `strokeMiterlimit` property to `Svg` class with default value of 4 per SVG spec (#35)
+- Added `visibility` attribute support (visible, hidden, collapse) (#59)
+- Added `display` attribute support (inline, block, none) (#59)
 
 ### Changed
 

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/core/SvgCodeGenerator.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/core/SvgCodeGenerator.kt
@@ -42,6 +42,8 @@ object SvgCodeGenerator {
     private val paintOrderClass = ClassName(corePackage, "PaintOrder")
     private val clipPathUnitsClass = ClassName(corePackage, "ClipPathUnits")
     private val maskUnitsClass = ClassName(corePackage, "MaskUnits")
+    private val visibilityClass = ClassName(corePackage, "Visibility")
+    private val displayClass = ClassName(corePackage, "Display")
     private val svgTransformClass = ClassName(corePackage, "SvgTransform")
     private val viewBoxClass = ClassName(corePackage, "ViewBox")
     private val preserveAspectRatioClass = ClassName(corePackage, "PreserveAspectRatio")
@@ -967,6 +969,26 @@ object SvgCodeGenerator {
             orderName?.let { styleParts.add(CodeBlock.of("paintOrder = %T.%L", paintOrderClass, it)) }
         }
 
+        mergedAttrs["visibility"]?.takeIf { it != "inherit" }?.lowercase()?.let { vis ->
+            val visName = when (vis) {
+                "visible" -> "VISIBLE"
+                "hidden" -> "HIDDEN"
+                "collapse" -> "COLLAPSE"
+                else -> null
+            }
+            visName?.let { styleParts.add(CodeBlock.of("visibility = %T.%L", visibilityClass, it)) }
+        }
+
+        mergedAttrs["display"]?.takeIf { it != "inherit" }?.lowercase()?.let { disp ->
+            val dispName = when (disp) {
+                "inline" -> "INLINE"
+                "block" -> "BLOCK"
+                "none" -> "NONE"
+                else -> null
+            }
+            dispName?.let { styleParts.add(CodeBlock.of("display = %T.%L", displayClass, it)) }
+        }
+
         if (styleParts.isEmpty()) {
             return element
         }
@@ -1271,6 +1293,26 @@ object SvgCodeGenerator {
         mergedAttrs["paint-order"]?.takeIf { it != "inherit" }?.let { paintOrder ->
             val orderName = parsePaintOrder(paintOrder)
             orderName?.let { styleParts.add(CodeBlock.of("paintOrder = %T.%L", paintOrderClass, it)) }
+        }
+
+        mergedAttrs["visibility"]?.takeIf { it != "inherit" }?.lowercase()?.let { vis ->
+            val visName = when (vis) {
+                "visible" -> "VISIBLE"
+                "hidden" -> "HIDDEN"
+                "collapse" -> "COLLAPSE"
+                else -> null
+            }
+            visName?.let { styleParts.add(CodeBlock.of("visibility = %T.%L", visibilityClass, it)) }
+        }
+
+        mergedAttrs["display"]?.takeIf { it != "inherit" }?.lowercase()?.let { disp ->
+            val dispName = when (disp) {
+                "inline" -> "INLINE"
+                "block" -> "BLOCK"
+                "none" -> "NONE"
+                else -> null
+            }
+            dispName?.let { styleParts.add(CodeBlock.of("display = %T.%L", displayClass, it)) }
         }
 
         if (styleParts.isEmpty()) {

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDrawing.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDrawing.kt
@@ -187,6 +187,11 @@ private fun DrawScope.drawStyledElement(
     styled: SvgStyled
 ) {
     val newCtx = applyStyle(context.ctx, styled.style)
+
+    // Skip rendering if display is none or visibility is hidden/collapse
+    if (newCtx.display == Display.NONE) return
+    if (newCtx.visibility == Visibility.HIDDEN || newCtx.visibility == Visibility.COLLAPSE) return
+
     val drawingCtx = context.withCtx(newCtx)
 
     val clipPathId = newCtx.clipPathId

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDrawingContext.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgDrawingContext.kt
@@ -20,7 +20,9 @@ data class DrawContext(
     val vectorEffect: VectorEffect = VectorEffect.NONE,
     val scaleFactor: Float = 1f,
     val clipPathId: String? = null,
-    val maskId: String? = null
+    val maskId: String? = null,
+    val visibility: Visibility = Visibility.VISIBLE,
+    val display: Display = Display.INLINE
 )
 
 /**

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
@@ -1456,6 +1456,20 @@ internal object SvgXmlParser {
         val transformValue = mergedAttrs["transform"]
         val transform = if (isInherit(transformValue)) null else transformValue?.let { parseTransform(it) }
         val paintOrder = parsePaintOrder(mergedAttrs["paint-order"])
+        val visibilityValue = mergedAttrs["visibility"]
+        val visibility = if (isInherit(visibilityValue)) null else when (visibilityValue?.lowercase()) {
+            "visible" -> Visibility.VISIBLE
+            "hidden" -> Visibility.HIDDEN
+            "collapse" -> Visibility.COLLAPSE
+            else -> null
+        }
+        val displayValue = mergedAttrs["display"]
+        val display = if (isInherit(displayValue)) null else when (displayValue?.lowercase()) {
+            "inline" -> Display.INLINE
+            "block" -> Display.BLOCK
+            "none" -> Display.NONE
+            else -> null
+        }
 
         // Only create style if at least one attribute is present
         if (fill == null && fillOpacity == null && fillRule == null &&
@@ -1463,7 +1477,7 @@ internal object SvgXmlParser {
             strokeLinecap == null && strokeLinejoin == null &&
             strokeDasharray == null && strokeDashoffset == null &&
             strokeMiterlimit == null && opacity == null && transform == null &&
-            paintOrder == null) {
+            paintOrder == null && visibility == null && display == null) {
             return null
         }
 
@@ -1481,7 +1495,9 @@ internal object SvgXmlParser {
             strokeMiterlimit = strokeMiterlimit,
             opacity = opacity,
             transform = transform,
-            paintOrder = paintOrder
+            paintOrder = paintOrder,
+            visibility = visibility,
+            display = display
         )
     }
 

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
@@ -51,6 +51,26 @@ enum class MaskUnits {
 }
 
 /**
+ * SVG visibility values.
+ * Controls whether an element is rendered.
+ */
+enum class Visibility {
+    VISIBLE,   // Default: element is rendered
+    HIDDEN,    // Element is not rendered but still affects layout
+    COLLAPSE   // Same as hidden for most elements
+}
+
+/**
+ * SVG display values.
+ * Controls how an element participates in layout and rendering.
+ */
+enum class Display {
+    INLINE,    // Default: element is rendered inline
+    BLOCK,     // Element is rendered as a block
+    NONE       // Element is not rendered and does not affect layout
+}
+
+/**
  * SVG transform.
  */
 sealed interface SvgTransform {
@@ -94,6 +114,8 @@ sealed interface SvgTransform {
  * @param markerStart Marker at the start of a path/line (e.g., "url(#arrow)")
  * @param markerMid Marker at middle vertices of a path
  * @param markerEnd Marker at the end of a path/line
+ * @param visibility Controls whether the element is rendered (visible, hidden, collapse)
+ * @param display Controls how the element participates in layout (inline, block, none)
  */
 data class SvgStyle(
     val fill: Color? = null,
@@ -115,7 +137,9 @@ data class SvgStyle(
     val maskId: String? = null,
     val markerStart: String? = null,
     val markerMid: String? = null,
-    val markerEnd: String? = null
+    val markerEnd: String? = null,
+    val visibility: Visibility? = null,
+    val display: Display? = null
 ) {
     companion object {
         val Empty = SvgStyle()

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
@@ -51,6 +51,8 @@ internal fun applyStyle(parent: DrawContext, style: SvgStyle): DrawContext {
     val vectorEffect = style.vectorEffect ?: parent.vectorEffect
     val clipPathId = style.clipPathId ?: parent.clipPathId
     val maskId = style.maskId ?: parent.maskId
+    val visibility = style.visibility ?: parent.visibility
+    val display = style.display ?: parent.display
 
     // Safely apply alpha to colors, handling special colors that can't be copied
     val finalStrokeColor = if (strokeColor.isSpecified) {
@@ -77,7 +79,9 @@ internal fun applyStyle(parent: DrawContext, style: SvgStyle): DrawContext {
         vectorEffect = vectorEffect,
         scaleFactor = parent.scaleFactor,
         clipPathId = clipPathId,
-        maskId = maskId
+        maskId = maskId,
+        visibility = visibility,
+        display = display
     )
 }
 

--- a/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
@@ -3442,4 +3442,145 @@ class SvgParserTest {
         val circleInherit = svgInherit.children[0]
         assertIs<SvgCircle>(circleInherit)
     }
+
+    // ===========================================
+    // Visibility Attribute Tests
+    // ===========================================
+
+    @Test
+    fun parseVisibilityVisible() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" visibility="visible"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Visibility.VISIBLE, (circle as SvgStyled).style.visibility)
+    }
+
+    @Test
+    fun parseVisibilityHidden() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" visibility="hidden"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Visibility.HIDDEN, (circle as SvgStyled).style.visibility)
+    }
+
+    @Test
+    fun parseVisibilityCollapse() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" visibility="collapse"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Visibility.COLLAPSE, (circle as SvgStyled).style.visibility)
+    }
+
+    @Test
+    fun parseVisibilityInherit() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" visibility="inherit"/>
+            </svg>
+        """.trimIndent())
+        // visibility="inherit" should result in no style
+        val circle = svg.children[0]
+        assertIs<SvgCircle>(circle)
+    }
+
+    @Test
+    fun parseVisibilityInStyleAttribute() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" style="visibility: hidden"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Visibility.HIDDEN, (circle as SvgStyled).style.visibility)
+    }
+
+    // ===========================================
+    // Display Attribute Tests
+    // ===========================================
+
+    @Test
+    fun parseDisplayInline() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" display="inline"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Display.INLINE, (circle as SvgStyled).style.display)
+    }
+
+    @Test
+    fun parseDisplayBlock() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" display="block"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Display.BLOCK, (circle as SvgStyled).style.display)
+    }
+
+    @Test
+    fun parseDisplayNone() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" display="none"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Display.NONE, (circle as SvgStyled).style.display)
+    }
+
+    @Test
+    fun parseDisplayInherit() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" display="inherit"/>
+            </svg>
+        """.trimIndent())
+        // display="inherit" should result in no style
+        val circle = svg.children[0]
+        assertIs<SvgCircle>(circle)
+    }
+
+    @Test
+    fun parseDisplayInStyleAttribute() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" style="display: none"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Display.NONE, (circle as SvgStyled).style.display)
+    }
+
+    @Test
+    fun parseVisibilityAndDisplayCombined() {
+        val svg = svg("""
+            <svg>
+                <circle cx="12" cy="12" r="10" visibility="hidden" display="block"/>
+            </svg>
+        """.trimIndent())
+        val circle = svg.children[0]
+        assertIs<SvgStyled>(circle)
+        assertEquals(Visibility.HIDDEN, (circle as SvgStyled).style.visibility)
+        assertEquals(Display.BLOCK, circle.style.display)
+    }
 }

--- a/sample/src/commonMain/svgicons/visibility-demo.svg
+++ b/sample/src/commonMain/svgicons/visibility-demo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Visible circle -->
+  <circle cx="6" cy="6" r="4" visibility="visible"/>
+  <!-- Hidden circle (should not render) -->
+  <circle cx="18" cy="6" r="4" visibility="hidden"/>
+  <!-- Visible rectangle -->
+  <rect x="2" y="14" width="8" height="8" display="inline"/>
+  <!-- Hidden rectangle (should not render) -->
+  <rect x="14" y="14" width="8" height="8" display="none"/>
+</svg>

--- a/sample/src/desktopMain/kotlin/io/github/fuyuz/svgicon/sample/Main.kt
+++ b/sample/src/desktopMain/kotlin/io/github/fuyuz/svgicon/sample/Main.kt
@@ -4,7 +4,8 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -562,6 +563,7 @@ fun main() = application {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun App() {
     MaterialTheme(colorScheme = darkColorScheme()) {
@@ -585,9 +587,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     AllIcons.entries.forEach { (name, svg) ->
                         Column(
@@ -615,9 +617,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -663,9 +665,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(24.dp),
-                    verticalAlignment = Alignment.Bottom
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     listOf(16.dp, 24.dp, 32.dp, 48.dp, 64.dp).forEach { iconSize ->
                         Column(
@@ -693,9 +695,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(24.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     listOf(
                         Color.White,
@@ -720,9 +722,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Loader - rotation animation (infinite)
                     Column(
@@ -773,9 +775,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Click-to-animate Bell
                     var bellAnimating by remember { mutableStateOf(false) }
@@ -842,9 +844,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Reverse animation on release
                     val reverseAnimationState = rememberSvgIconAnimationState()
@@ -921,9 +923,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Original (no transform)
                     val originalSvg = remember {
@@ -1022,9 +1024,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Simple DSL check
                     Column(
@@ -1145,9 +1147,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // withStyle scope
                     Column(
@@ -1212,9 +1214,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Animated check (staggered)
                     Column(
@@ -1265,9 +1267,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Path morphing
                     Column(
@@ -1346,9 +1348,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Fill opacity
                     Column(
@@ -1427,9 +1429,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Star icon parsed from SVG string
                     val starSvg = remember {
@@ -1501,9 +1503,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Inline style: fill color
                     val inlineStyleFill = remember {
@@ -1596,9 +1598,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Class selector
                     val classSelector = remember {
@@ -1696,9 +1698,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Translate with X and Y values (Issue #30)
                     val translateXYSvg = remember {
@@ -1779,9 +1781,9 @@ fun App() {
                     color = Color.Gray
                 )
 
-                Row(
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(32.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Spin animation
                     val spinAnimation = remember {


### PR DESCRIPTION
## Summary
- Added support for SVG `visibility` attribute (visible, hidden, collapse)
- Added support for SVG `display` attribute (inline, block, none)
- Elements with `visibility="hidden"`, `visibility="collapse"`, or `display="none"` are not rendered

## Changes
- `SvgStyle.kt`: Added `Visibility` and `Display` enums, and corresponding properties to `SvgStyle`
- `SvgParser.kt`: Parse visibility and display attributes
- `SvgDrawingContext.kt`: Added visibility and display to `DrawContext`
- `SvgStyleApplier.kt`: Apply visibility and display inheritance
- `SvgDrawing.kt`: Skip rendering when visibility is hidden/collapse or display is none
- `SvgCodeGenerator.kt`: Generate code for visibility and display attributes

## Test plan
- [x] Added unit tests for parsing visibility attribute (visible, hidden, collapse, inherit)
- [x] Added unit tests for parsing display attribute (inline, block, none, inherit)
- [x] Added tests for CSS style attribute parsing
- [x] Added combined visibility and display test
- [x] Desktop compilation passes
- [x] Sample icon added to demonstrate the feature
- [x] All existing tests pass

Closes #59