### PR TITLE
Add SVG2 stroke-linejoin values: miter-clip and arcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Added support for SVG2 `stroke-linejoin` values: `miter-clip` and `arcs` (#50)
-  - `miter-clip` falls back to `miter` at render time (Compose limitation)
-  - `arcs` falls back to `bevel` at render time (Compose limitation)
+  - These values are parsed but will throw an error at render time (Compose limitation)
 - Implemented `paint-order` attribute support for controlling fill/stroke drawing order (#40)
 - Added support for `inherit` keyword in style attributes (fill, stroke, opacity, stroke-width, etc.) (#61)
 - Added `strokeMiterlimit` property to `Svg` class with default value of 4 per SVG spec (#35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Added support for SVG2 `stroke-linejoin` values: `miter-clip` and `arcs` (#50)
+  - `miter-clip` falls back to `miter` at render time (Compose limitation)
+  - `arcs` falls back to `bevel` at render time (Compose limitation)
 - Implemented `paint-order` attribute support for controlling fill/stroke drawing order (#40)
 - Added support for `inherit` keyword in style attributes (fill, stroke, opacity, stroke-width, etc.) (#61)
 - Added `strokeMiterlimit` property to `Svg` class with default value of 4 per SVG spec (#35)

--- a/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/core/SvgCodeGenerator.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/fuyuz/svgicon/core/SvgCodeGenerator.kt
@@ -191,6 +191,8 @@ object SvgCodeGenerator {
             val joinName = when (linejoin) {
                 "round" -> "ROUND"
                 "bevel" -> "BEVEL"
+                "miter-clip" -> "MITER_CLIP"
+                "arcs" -> "ARCS"
                 else -> "MITER"
             }
             builder.add("strokeLinejoin = %T.%L,\n", lineJoinClass, joinName)
@@ -949,8 +951,10 @@ object SvgCodeGenerator {
         mergedAttrs["stroke-linejoin"]?.takeIf { it != "inherit" }?.lowercase()?.let { join ->
             val joinName = when (join) {
                 "miter" -> "MITER"
+                "miter-clip" -> "MITER_CLIP"
                 "bevel" -> "BEVEL"
                 "round" -> "ROUND"
+                "arcs" -> "ARCS"
                 else -> null
             }
             joinName?.let { styleParts.add(CodeBlock.of("strokeLinejoin = %T.%L", lineJoinClass, it)) }
@@ -1304,8 +1308,10 @@ object SvgCodeGenerator {
         mergedAttrs["stroke-linejoin"]?.takeIf { it != "inherit" }?.lowercase()?.let { join ->
             val joinName = when (join) {
                 "miter" -> "MITER"
+                "miter-clip" -> "MITER_CLIP"
                 "bevel" -> "BEVEL"
                 "round" -> "ROUND"
+                "arcs" -> "ARCS"
                 else -> null
             }
             joinName?.let { styleParts.add(CodeBlock.of("strokeLinejoin = %T.%L", lineJoinClass, it)) }

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgParser.kt
@@ -116,6 +116,8 @@ internal object SvgXmlParser {
         val strokeLinejoin = when (attrs["stroke-linejoin"]?.lowercase()) {
             "round" -> LineJoin.ROUND
             "bevel" -> LineJoin.BEVEL
+            "miter-clip" -> LineJoin.MITER_CLIP
+            "arcs" -> LineJoin.ARCS
             else -> LineJoin.MITER
         }
         val strokeMiterlimit = attrs["stroke-miterlimit"]?.toFloatOrNull() ?: 4f
@@ -1444,8 +1446,10 @@ internal object SvgXmlParser {
         val strokeLinejoinValue = mergedAttrs["stroke-linejoin"]
         val strokeLinejoin = if (isInherit(strokeLinejoinValue)) null else when (strokeLinejoinValue?.lowercase()) {
             "miter" -> LineJoin.MITER
+            "miter-clip" -> LineJoin.MITER_CLIP
             "round" -> LineJoin.ROUND
             "bevel" -> LineJoin.BEVEL
+            "arcs" -> LineJoin.ARCS
             else -> null
         }
         val strokeDasharrayValue = mergedAttrs["stroke-dasharray"]

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
@@ -16,14 +16,14 @@ enum class LineCap { BUTT, ROUND, SQUARE }
  * SVG stroke-linejoin values.
  *
  * Note: MITER_CLIP and ARCS are SVG2 values. Compose only supports Miter, Round, and Bevel,
- * so MITER_CLIP falls back to MITER and ARCS falls back to BEVEL at render time.
+ * so using MITER_CLIP or ARCS will throw an error at render time.
  */
 enum class LineJoin {
     MITER,
-    MITER_CLIP,  // SVG2: Falls back to MITER in Compose
+    MITER_CLIP,  // SVG2: Not supported by Compose
     ROUND,
     BEVEL,
-    ARCS         // SVG2: Falls back to BEVEL in Compose
+    ARCS         // SVG2: Not supported by Compose
 }
 
 /**

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyle.kt
@@ -14,8 +14,17 @@ enum class LineCap { BUTT, ROUND, SQUARE }
 
 /**
  * SVG stroke-linejoin values.
+ *
+ * Note: MITER_CLIP and ARCS are SVG2 values. Compose only supports Miter, Round, and Bevel,
+ * so MITER_CLIP falls back to MITER and ARCS falls back to BEVEL at render time.
  */
-enum class LineJoin { MITER, ROUND, BEVEL }
+enum class LineJoin {
+    MITER,
+    MITER_CLIP,  // SVG2: Falls back to MITER in Compose
+    ROUND,
+    BEVEL,
+    ARCS         // SVG2: Falls back to BEVEL in Compose
+}
 
 /**
  * Paint order determines the order in which fill and stroke are painted.

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
@@ -165,10 +165,10 @@ internal fun LineCap.toCompose(): StrokeCap = when (this) {
 
 internal fun LineJoin.toCompose(): StrokeJoin = when (this) {
     LineJoin.MITER -> StrokeJoin.Miter
-    LineJoin.MITER_CLIP -> StrokeJoin.Miter  // SVG2: falls back to Miter
+    LineJoin.MITER_CLIP -> error("stroke-linejoin: miter-clip is not supported by Compose")
     LineJoin.ROUND -> StrokeJoin.Round
     LineJoin.BEVEL -> StrokeJoin.Bevel
-    LineJoin.ARCS -> StrokeJoin.Bevel  // SVG2: falls back to Bevel
+    LineJoin.ARCS -> error("stroke-linejoin: arcs is not supported by Compose")
 }
 
 internal fun FillRule.toCompose(): PathFillType = when (this) {

--- a/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
+++ b/runtime/src/commonMain/kotlin/io/github/fuyuz/svgicon/core/SvgStyleApplier.kt
@@ -165,8 +165,10 @@ internal fun LineCap.toCompose(): StrokeCap = when (this) {
 
 internal fun LineJoin.toCompose(): StrokeJoin = when (this) {
     LineJoin.MITER -> StrokeJoin.Miter
+    LineJoin.MITER_CLIP -> StrokeJoin.Miter  // SVG2: falls back to Miter
     LineJoin.ROUND -> StrokeJoin.Round
     LineJoin.BEVEL -> StrokeJoin.Bevel
+    LineJoin.ARCS -> StrokeJoin.Bevel  // SVG2: falls back to Bevel
 }
 
 internal fun FillRule.toCompose(): PathFillType = when (this) {

--- a/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgParserTest.kt
@@ -1725,6 +1725,22 @@ class SvgParserTest {
     }
 
     @Test
+    fun parseStrokeLinejoinMiterClip() {
+        val svg = svg("""<svg><path d="M0 0" stroke-linejoin="miter-clip"/></svg>""")
+        val styled = svg.children[0]
+        assertIs<SvgStyled>(styled)
+        assertEquals(LineJoin.MITER_CLIP, styled.style.strokeLinejoin)
+    }
+
+    @Test
+    fun parseStrokeLinejoinArcs() {
+        val svg = svg("""<svg><path d="M0 0" stroke-linejoin="arcs"/></svg>""")
+        val styled = svg.children[0]
+        assertIs<SvgStyled>(styled)
+        assertEquals(LineJoin.ARCS, styled.style.strokeLinejoin)
+    }
+
+    @Test
     fun parseStrokeDasharrayWithSpaces() {
         val svg = svg("""<svg><line x1="0" y1="0" x2="10" y2="10" stroke-dasharray="5 3 2"/></svg>""")
         val styled = svg.children[0]
@@ -3017,6 +3033,18 @@ class SvgParserTest {
     fun parseSvgWithStrokeLinejoinMiter() {
         val svg = svg("""<svg stroke-linejoin="miter"><path d="M0 0 L10 10"/></svg>""")
         assertEquals(LineJoin.MITER, svg.strokeLinejoin)
+    }
+
+    @Test
+    fun parseSvgWithStrokeLinejoinMiterClip() {
+        val svg = svg("""<svg stroke-linejoin="miter-clip"><path d="M0 0 L10 10"/></svg>""")
+        assertEquals(LineJoin.MITER_CLIP, svg.strokeLinejoin)
+    }
+
+    @Test
+    fun parseSvgWithStrokeLinejoinArcs() {
+        val svg = svg("""<svg stroke-linejoin="arcs"><path d="M0 0 L10 10"/></svg>""")
+        assertEquals(LineJoin.ARCS, svg.strokeLinejoin)
     }
 
     @Test

--- a/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgStyleTest.kt
+++ b/runtime/src/commonTest/kotlin/io/github/fuyuz/svgicon/core/SvgStyleTest.kt
@@ -157,10 +157,12 @@ class SvgStyleTest {
 
     @Test
     fun lineJoinValues() {
-        assertEquals(3, LineJoin.entries.size)
+        assertEquals(5, LineJoin.entries.size)
         assertTrue(LineJoin.entries.contains(LineJoin.MITER))
+        assertTrue(LineJoin.entries.contains(LineJoin.MITER_CLIP))
         assertTrue(LineJoin.entries.contains(LineJoin.ROUND))
         assertTrue(LineJoin.entries.contains(LineJoin.BEVEL))
+        assertTrue(LineJoin.entries.contains(LineJoin.ARCS))
     }
 
     // ===========================================


### PR DESCRIPTION
## Summary
- Added support for SVG2 `stroke-linejoin` values: `miter-clip` and `arcs`
- These values are parsed correctly but throw an error at render time (Compose only supports miter, round, bevel)

## Changes
- `SvgStyle.kt`: Added `MITER_CLIP` and `ARCS` to `LineJoin` enum
- `SvgParser.kt`: Updated stroke-linejoin parsing to recognize new values
- `SvgStyleApplier.kt`: Throws error for unsupported values instead of silent fallback
- `SvgCodeGenerator.kt`: Updated code generation to handle new values

## Test plan
- [x] Added unit tests for `miter-clip` and `arcs` parsing
- [x] Updated `LineJoin` enum test to verify all 5 values
- [x] Verified runtime and sample builds succeed

Closes #50